### PR TITLE
Use $OPTIONS variable during ExecStartPre and ExecReload

### DIFF
--- a/SOURCES/haproxy.service
+++ b/SOURCES/haproxy.service
@@ -7,7 +7,7 @@ Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid"
 EnvironmentFile=-/etc/sysconfig/haproxy
 ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $OPTIONS
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE $OPTIONS
-ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q
+ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q $OPTIONS
 ExecReload=/bin/kill -USR2 $MAINPID
 KillMode=mixed
 Type=notify

--- a/SOURCES/haproxy.service
+++ b/SOURCES/haproxy.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid"
 EnvironmentFile=-/etc/sysconfig/haproxy
-ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q
+ExecStartPre=/usr/sbin/haproxy -f $CONFIG -c -q $OPTIONS
 ExecStart=/usr/sbin/haproxy -Ws -f $CONFIG -p $PIDFILE $OPTIONS
 ExecReload=/usr/sbin/haproxy -f $CONFIG -c -q
 ExecReload=/bin/kill -USR2 $MAINPID


### PR DESCRIPTION
We are using the `-f` option in our  `/etc/sysconfig/haproxy` file. To verify our config file completely we need the `$OPTIONS` variable in the `ExecStartPre` command.

To reload haproxy.service we need the `$OPTION` variable at `ExecReload` command as well.