### PR TITLE
Minor variable reference issue

### DIFF
--- a/SPECS/haproxy18u.spec
+++ b/SPECS/haproxy18u.spec
@@ -125,7 +125,7 @@ done
 getent group %{haproxy_group} >/dev/null || \
     groupadd -r %{haproxy_group}
 getent passwd %{haproxy_user} >/dev/null || \
-    useradd -r -g %{haproxy_user} -d %{haproxy_home} \
+    useradd -r -g %{haproxy_group} -d %{haproxy_home} \
     -s /sbin/nologin -c "haproxy" %{haproxy_user}
 exit 0
 


### PR DESCRIPTION
I think in the `useradd` statement, you intended to use the `haproxy_group` variable as a group argument, rather than the username.

Today, there's no issues with this as the username and group variables contain the same value, but this will break if this relationship changes in the future.