### PR TITLE
HAProxy 1.8.31

### DIFF
--- a/haproxy18u.spec
+++ b/haproxy18u.spec
@@ -7,7 +7,7 @@
 %global _hardened_build 1
 
 Name:           haproxy18u
-Version:        1.8.30
+Version:        1.8.31
 Release:        1%{?dist}
 Summary:        HAProxy reverse proxy for high availability environments
 
@@ -158,6 +158,9 @@ exit 0
 %{_mandir}/man1/*
 
 %changelog
+* Tue May 02 2023 Christian Boenning <christian@boenning.io> - 1.8.31-1
+- HAProxy 1.8.31
+ 
 * Fri Oct 01 2021 Carl George <carl@george.computer> - 1.8.30-1
 - Latest upstream
 


### PR DESCRIPTION
That would mark latest (and last) release of the HAProxy 1.8 series which was EOLed a while ago.